### PR TITLE
Clean

### DIFF
--- a/app/src/main/java/com/buggily/ify/ui/IfyViewModel.kt
+++ b/app/src/main/java/com/buggily/ify/ui/IfyViewModel.kt
@@ -2,6 +2,7 @@ package com.buggily.ify.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.buggily.ify.core.domain.FormatCapitalize
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -13,7 +14,9 @@ import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
-class IfyViewModel @Inject constructor() : ViewModel() {
+class IfyViewModel @Inject constructor(
+    private val formatCapitalize: FormatCapitalize,
+) : ViewModel() {
 
     private val _uiState: MutableStateFlow<IfyUiState>
     val uiState: StateFlow<IfyUiState> get() = _uiState
@@ -29,7 +32,7 @@ class IfyViewModel @Inject constructor() : ViewModel() {
             ),
         ).let { _uiState = MutableStateFlow(it) }
 
-        name = uiState.map { it.nameState.name }.debounce(1000).stateIn(
+        name = uiState.map { formatCapitalize(it.nameState.name) }.debounce(1000).stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(),
             initialValue = uiState.value.nameState.name,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 
     alias(libs.plugins.kotlin) apply false
     alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.kotlin.compose) apply false
 
     alias(libs.plugins.hilt) apply false
 }

--- a/core/domain/src/main/java/com/buggily/ify/core/domain/Format.kt
+++ b/core/domain/src/main/java/com/buggily/ify/core/domain/Format.kt
@@ -4,7 +4,6 @@ import java.util.Locale
 
 class Format(
     val locale: Locale,
-    val formatLowercase: FormatLowercase,
     val formatNumber: FormatNumber,
     val formatProbability: FormatProbability,
 )

--- a/core/domain/src/main/java/com/buggily/ify/core/domain/FormatCapitalize.kt
+++ b/core/domain/src/main/java/com/buggily/ify/core/domain/FormatCapitalize.kt
@@ -1,0 +1,10 @@
+package com.buggily.ify.core.domain
+
+import java.util.Locale
+
+class FormatCapitalize(
+    private val locale: Locale,
+) {
+
+    operator fun invoke(string: String): String = string.capitalize(locale)
+}

--- a/core/domain/src/main/java/com/buggily/ify/core/domain/FormatUppercase.kt
+++ b/core/domain/src/main/java/com/buggily/ify/core/domain/FormatUppercase.kt
@@ -1,0 +1,10 @@
+package com.buggily.ify.core.domain
+
+import java.util.Locale
+
+class FormatUppercase(
+    private val locale: Locale,
+) {
+
+    operator fun invoke(string: String): String = string.uppercase(locale)
+}

--- a/core/domain/src/main/java/com/buggily/ify/core/domain/di/FormatCapitalizeProvider.kt
+++ b/core/domain/src/main/java/com/buggily/ify/core/domain/di/FormatCapitalizeProvider.kt
@@ -1,18 +1,20 @@
 package com.buggily.ify.core.domain.di
 
+import com.buggily.ify.core.domain.FormatCapitalize
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import java.text.NumberFormat
 import java.util.Locale
 
 @Module
 @InstallIn(SingletonComponent::class)
-internal object NumberFormatProvider {
+internal object FormatCapitalizeProvider {
 
     @Provides
     fun provides(
         locale: Locale,
-    ): NumberFormat = NumberFormat.getInstance(locale)
+    ): FormatCapitalize = FormatCapitalize(
+        locale = locale,
+    )
 }

--- a/core/domain/src/main/java/com/buggily/ify/core/domain/di/FormatLowercaseProvider.kt
+++ b/core/domain/src/main/java/com/buggily/ify/core/domain/di/FormatLowercaseProvider.kt
@@ -9,7 +9,7 @@ import java.util.Locale
 
 @Module
 @InstallIn(SingletonComponent::class)
-object FormatLowercaseProvider {
+internal object FormatLowercaseProvider {
 
     @Provides
     fun provides(

--- a/core/domain/src/main/java/com/buggily/ify/core/domain/di/FormatNumberProvider.kt
+++ b/core/domain/src/main/java/com/buggily/ify/core/domain/di/FormatNumberProvider.kt
@@ -9,7 +9,7 @@ import java.text.NumberFormat
 
 @Module
 @InstallIn(SingletonComponent::class)
-object FormatNumberProvider {
+internal object FormatNumberProvider {
 
     @Provides
     fun provides(

--- a/core/domain/src/main/java/com/buggily/ify/core/domain/di/FormatProbabilityProvider.kt
+++ b/core/domain/src/main/java/com/buggily/ify/core/domain/di/FormatProbabilityProvider.kt
@@ -8,7 +8,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object FormatProbabilityProvider {
+internal object FormatProbabilityProvider {
 
     @Provides
     fun provides(): FormatProbability = FormatProbability()

--- a/core/domain/src/main/java/com/buggily/ify/core/domain/di/FormatProvider.kt
+++ b/core/domain/src/main/java/com/buggily/ify/core/domain/di/FormatProvider.kt
@@ -1,7 +1,6 @@
 package com.buggily.ify.core.domain.di
 
 import com.buggily.ify.core.domain.Format
-import com.buggily.ify.core.domain.FormatLowercase
 import com.buggily.ify.core.domain.FormatNumber
 import com.buggily.ify.core.domain.FormatProbability
 import dagger.Module
@@ -12,17 +11,15 @@ import java.util.Locale
 
 @Module
 @InstallIn(SingletonComponent::class)
-object FormatProvider {
+internal object FormatProvider {
 
     @Provides
     fun provides(
         locale: Locale,
-        formatLowercase: FormatLowercase,
         formatNumber: FormatNumber,
         formatProbability: FormatProbability,
     ): Format = Format(
         locale = locale,
-        formatLowercase = formatLowercase,
         formatNumber = formatNumber,
         formatProbability = formatProbability,
     )

--- a/core/domain/src/main/java/com/buggily/ify/core/domain/di/FormatUppercaseProvider.kt
+++ b/core/domain/src/main/java/com/buggily/ify/core/domain/di/FormatUppercaseProvider.kt
@@ -1,18 +1,20 @@
 package com.buggily.ify.core.domain.di
 
+import com.buggily.ify.core.domain.FormatUppercase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import java.text.NumberFormat
 import java.util.Locale
 
 @Module
 @InstallIn(SingletonComponent::class)
-internal object NumberFormatProvider {
+internal object FormatUppercaseProvider {
 
     @Provides
     fun provides(
         locale: Locale,
-    ): NumberFormat = NumberFormat.getInstance(locale)
+    ): FormatUppercase = FormatUppercase(
+        locale = locale,
+    )
 }

--- a/core/domain/src/main/java/com/buggily/ify/core/domain/di/LocaleProvider.kt
+++ b/core/domain/src/main/java/com/buggily/ify/core/domain/di/LocaleProvider.kt
@@ -8,7 +8,7 @@ import java.util.Locale
 
 @Module
 @InstallIn(SingletonComponent::class)
-object LocaleProvider {
+internal object LocaleProvider {
 
     @Provides
     fun provides(): Locale = Locale.getDefault()

--- a/core/local/src/main/java/com/buggily/ify/core/local/di/IfyDatabaseableProvider.kt
+++ b/core/local/src/main/java/com/buggily/ify/core/local/di/IfyDatabaseableProvider.kt
@@ -12,7 +12,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object IfyDatabaseableProvider {
+internal object IfyDatabaseableProvider {
 
     @Provides
     fun provides(

--- a/core/local/src/main/java/com/buggily/ify/core/local/di/age/LocalAgeDaoProvider.kt
+++ b/core/local/src/main/java/com/buggily/ify/core/local/di/age/LocalAgeDaoProvider.kt
@@ -9,7 +9,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object LocalAgeDaoProvider {
+internal object LocalAgeDaoProvider {
 
     @Provides
     fun provides(

--- a/core/local/src/main/java/com/buggily/ify/core/local/di/gender/LocalGenderDaoProvider.kt
+++ b/core/local/src/main/java/com/buggily/ify/core/local/di/gender/LocalGenderDaoProvider.kt
@@ -9,7 +9,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object LocalGenderDaoProvider {
+internal object LocalGenderDaoProvider {
 
     @Provides
     fun provides(

--- a/core/local/src/main/java/com/buggily/ify/core/local/di/nationality/LocalNationalityDaoProvider.kt
+++ b/core/local/src/main/java/com/buggily/ify/core/local/di/nationality/LocalNationalityDaoProvider.kt
@@ -9,7 +9,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object LocalNationalityDaoProvider {
+internal object LocalNationalityDaoProvider {
 
     @Provides
     fun provides(

--- a/core/remote/src/main/java/com/buggily/core/remote/di/JsonContentTypeProvider.kt
+++ b/core/remote/src/main/java/com/buggily/core/remote/di/JsonContentTypeProvider.kt
@@ -8,7 +8,7 @@ import okhttp3.MediaType
 
 @Module
 @InstallIn(SingletonComponent::class)
-object JsonContentTypeProvider {
+internal object JsonContentTypeProvider {
 
     @Provides
     @JsonContentTypeQualifier

--- a/core/remote/src/main/java/com/buggily/core/remote/di/JsonConverterFactoryProvider.kt
+++ b/core/remote/src/main/java/com/buggily/core/remote/di/JsonConverterFactoryProvider.kt
@@ -11,7 +11,7 @@ import retrofit2.Converter
 
 @Module
 @InstallIn(SingletonComponent::class)
-object JsonConverterFactoryProvider {
+internal object JsonConverterFactoryProvider {
 
     @Provides
     @JsonConverterFactoryQualifier

--- a/core/remote/src/main/java/com/buggily/core/remote/di/RestCallAdapterFactoryProvider.kt
+++ b/core/remote/src/main/java/com/buggily/core/remote/di/RestCallAdapterFactoryProvider.kt
@@ -9,7 +9,7 @@ import retrofit2.CallAdapter
 
 @Module
 @InstallIn(SingletonComponent::class)
-object RestCallAdapterFactoryProvider {
+internal object RestCallAdapterFactoryProvider {
 
     @Provides
     @RestCallAdapterFactoryQualifier

--- a/core/remote/src/main/java/com/buggily/core/remote/di/RetrofitBuilderProvider.kt
+++ b/core/remote/src/main/java/com/buggily/core/remote/di/RetrofitBuilderProvider.kt
@@ -10,7 +10,7 @@ import retrofit2.Retrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
-object RetrofitBuilderProvider {
+internal object RetrofitBuilderProvider {
 
     @Provides
     fun provides(

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -3,5 +3,5 @@
     <string name="unknown">unknown</string>
 
     <string name="error_network">Whoops, we can not reach the endpoint.</string>
-    <string name="error_else">Whoops, something is wrong.</string>
+    <string name="error_unknown">Whoops, something is wrong.</string>
 </resources>

--- a/data/age/src/main/java/com/buggily/ify/data/age/AgeRepository.kt
+++ b/data/age/src/main/java/com/buggily/ify/data/age/AgeRepository.kt
@@ -7,7 +7,7 @@ import com.buggily.ify.remote.age.RemoteAge
 import com.buggily.ify.remote.age.RemoteAgeSourceable
 import kotlinx.coroutines.flow.firstOrNull
 
-class AgeRepository(
+internal class AgeRepository(
     private val remoteAgeSource: RemoteAgeSourceable,
     private val localAgeSource: LocalAgeSourceable,
 ) : AgeRepositable {

--- a/data/age/src/main/java/com/buggily/ify/data/age/di/AgeRepositableProvider.kt
+++ b/data/age/src/main/java/com/buggily/ify/data/age/di/AgeRepositableProvider.kt
@@ -11,7 +11,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object AgeRepositableProvider {
+internal object AgeRepositableProvider {
 
     @Provides
     fun provides(

--- a/data/gender/src/main/java/com/buggily/ify/data/gender/GenderRepository.kt
+++ b/data/gender/src/main/java/com/buggily/ify/data/gender/GenderRepository.kt
@@ -7,7 +7,7 @@ import com.buggily.ify.remote.gender.RemoteGender
 import com.buggily.ify.remote.gender.RemoteGenderSourceable
 import kotlinx.coroutines.flow.firstOrNull
 
-class GenderRepository(
+internal class GenderRepository(
     private val remoteGenderSource: RemoteGenderSourceable,
     private val localGenderSource: LocalGenderSourceable,
 ) : GenderRepositable {

--- a/data/gender/src/main/java/com/buggily/ify/data/gender/di/GenderRepositableProvider.kt
+++ b/data/gender/src/main/java/com/buggily/ify/data/gender/di/GenderRepositableProvider.kt
@@ -11,7 +11,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object GenderRepositableProvider {
+internal object GenderRepositableProvider {
 
     @Provides
     fun provides(

--- a/data/nationality/src/main/java/com/buggily/ify/data/nationality/NationalityRepository.kt
+++ b/data/nationality/src/main/java/com/buggily/ify/data/nationality/NationalityRepository.kt
@@ -8,7 +8,7 @@ import com.buggily.ify.remote.nationality.RemoteNationality
 import com.buggily.ify.remote.nationality.RemoteNationalitySourceable
 import kotlinx.coroutines.flow.firstOrNull
 
-class NationalityRepository(
+internal class NationalityRepository(
     private val remoteNationalitySource: RemoteNationalitySourceable,
     private val localNationalitySource: LocalNationalitySourceable,
     private val localNationalityCountrySource: LocalNationalityCountrySourceable

--- a/data/nationality/src/main/java/com/buggily/ify/data/nationality/di/NationalityRepositableProvider.kt
+++ b/data/nationality/src/main/java/com/buggily/ify/data/nationality/di/NationalityRepositableProvider.kt
@@ -12,7 +12,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object NationalityRepositableProvider {
+internal object NationalityRepositableProvider {
 
     @Provides
     fun provides(

--- a/domain/age/src/main/java/com/buggily/ify/domain/age/di/GetAgeByNameProvider.kt
+++ b/domain/age/src/main/java/com/buggily/ify/domain/age/di/GetAgeByNameProvider.kt
@@ -10,7 +10,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object GetAgeByNameProvider {
+internal object GetAgeByNameProvider {
 
     @Provides
     fun provides(

--- a/domain/gender/src/main/java/com/buggily/ify/domain/gender/di/GetByNameGenderProvider.kt
+++ b/domain/gender/src/main/java/com/buggily/ify/domain/gender/di/GetByNameGenderProvider.kt
@@ -10,7 +10,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object GetByNameGenderProvider {
+internal object GetByNameGenderProvider {
 
     @Provides
     fun provides(

--- a/domain/nationality/src/main/java/com/buggily/ify/domain/nationality/di/GetNationalityByNameProvider.kt
+++ b/domain/nationality/src/main/java/com/buggily/ify/domain/nationality/di/GetNationalityByNameProvider.kt
@@ -10,7 +10,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object GetNationalityByNameProvider {
+internal object GetNationalityByNameProvider {
 
     @Provides
     fun provides(

--- a/feature/age/src/main/java/com/buggily/ify/feature/age/AgeUi.kt
+++ b/feature/age/src/main/java/com/buggily/ify/feature/age/AgeUi.kt
@@ -93,7 +93,7 @@ private fun AgeFailure(
     val text: String = when (uiState) {
         is AgeUiState.Failure.Remote.Api -> uiState.message
         is AgeUiState.Failure.Remote.Network -> stringResource(CR.string.error_network)
-        is AgeUiState.Failure.Else -> stringResource(CR.string.error_else)
+        is AgeUiState.Failure.Else -> stringResource(CR.string.error_unknown)
     }
 
     FailureText(

--- a/feature/gender/src/main/java/com/buggily/ify/feature/gender/GenderUi.kt
+++ b/feature/gender/src/main/java/com/buggily/ify/feature/gender/GenderUi.kt
@@ -108,7 +108,7 @@ private fun GenderFailure(
     val text: String = when (uiState) {
         is GenderUiState.Failure.Remote.Api -> uiState.message
         is GenderUiState.Failure.Remote.Network -> stringResource(CR.string.error_network)
-        is GenderUiState.Failure.Else -> stringResource(CR.string.error_else)
+        is GenderUiState.Failure.Else -> stringResource(CR.string.error_unknown)
     }
 
     FailureText(

--- a/feature/nationality/src/main/java/com/buggily/ify/feature/nationality/NationalityUi.kt
+++ b/feature/nationality/src/main/java/com/buggily/ify/feature/nationality/NationalityUi.kt
@@ -93,7 +93,7 @@ private fun NationalityFailure(
     val text: String = when (uiState) {
         is NationalityUiState.Failure.Remote.Api -> uiState.message
         is NationalityUiState.Failure.Remote.Network -> stringResource(CR.string.error_network)
-        is NationalityUiState.Failure.Else -> stringResource(CR.string.error_else)
+        is NationalityUiState.Failure.Else -> stringResource(CR.string.error_unknown)
     }
 
     FailureText(

--- a/local/age/src/main/java/com/buggily/ify/local/age/LocalAgeSource.kt
+++ b/local/age/src/main/java/com/buggily/ify/local/age/LocalAgeSource.kt
@@ -2,7 +2,7 @@ package com.buggily.ify.local.age
 
 import kotlinx.coroutines.flow.Flow
 
-class LocalAgeSource(
+internal class LocalAgeSource(
     private val localAgeDao: LocalAgeDao,
 ) : LocalAgeSourceable {
 

--- a/local/age/src/main/java/com/buggily/ify/local/age/di/LocalAgeSourceableProvider.kt
+++ b/local/age/src/main/java/com/buggily/ify/local/age/di/LocalAgeSourceableProvider.kt
@@ -10,7 +10,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object LocalAgeSourceableProvider {
+internal object LocalAgeSourceableProvider {
 
     @Provides
     fun provides(

--- a/local/gender/src/main/java/com/buggily/ify/local/gender/LocalGenderSource.kt
+++ b/local/gender/src/main/java/com/buggily/ify/local/gender/LocalGenderSource.kt
@@ -2,7 +2,7 @@ package com.buggily.ify.local.gender
 
 import kotlinx.coroutines.flow.Flow
 
-class LocalGenderSource(
+internal class LocalGenderSource(
     private val localGenderDao: LocalGenderDao,
 ) : LocalGenderSourceable {
 

--- a/local/gender/src/main/java/com/buggily/ify/local/gender/di/LocalGenderSourceableProvider.kt
+++ b/local/gender/src/main/java/com/buggily/ify/local/gender/di/LocalGenderSourceableProvider.kt
@@ -10,7 +10,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object LocalGenderSourceableProvider {
+internal object LocalGenderSourceableProvider {
 
     @Provides
     fun provides(

--- a/local/nationality/src/main/java/com/buggily/ify/local/nationality/LocalNationalitySource.kt
+++ b/local/nationality/src/main/java/com/buggily/ify/local/nationality/LocalNationalitySource.kt
@@ -2,7 +2,7 @@ package com.buggily.ify.local.nationality
 
 import kotlinx.coroutines.flow.Flow
 
-class LocalNationalitySource(
+internal class LocalNationalitySource(
     private val localNationalityDao: LocalNationalityDao,
 ) : LocalNationalitySourceable {
 

--- a/local/nationality/src/main/java/com/buggily/ify/local/nationality/country/LocalNationalityCountrySource.kt
+++ b/local/nationality/src/main/java/com/buggily/ify/local/nationality/country/LocalNationalityCountrySource.kt
@@ -1,6 +1,6 @@
 package com.buggily.ify.local.nationality.country
 
-class LocalNationalityCountrySource(
+internal class LocalNationalityCountrySource(
     private val localNationalityCountryDao: LocalNationalityCountryDao,
 ) : LocalNationalityCountrySourceable {
 

--- a/local/nationality/src/main/java/com/buggily/ify/local/nationality/di/LocalNationalitySourceableProvider.kt
+++ b/local/nationality/src/main/java/com/buggily/ify/local/nationality/di/LocalNationalitySourceableProvider.kt
@@ -10,7 +10,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object LocalNationalitySourceableProvider {
+internal object LocalNationalitySourceableProvider {
 
     @Provides
     fun provides(

--- a/local/nationality/src/main/java/com/buggily/ify/local/nationality/di/country/LocalNationalityCountrySourceableProvider.kt
+++ b/local/nationality/src/main/java/com/buggily/ify/local/nationality/di/country/LocalNationalityCountrySourceableProvider.kt
@@ -10,7 +10,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object LocalNationalityCountrySourceableProvider {
+internal object LocalNationalityCountrySourceableProvider {
 
     @Provides
     fun provides(

--- a/remote/age/src/main/java/com/buggily/ify/remote/age/RemoteAgeServiceable.kt
+++ b/remote/age/src/main/java/com/buggily/ify/remote/age/RemoteAgeServiceable.kt
@@ -4,7 +4,7 @@ import com.buggily.core.remote.ApiResult
 import retrofit2.http.GET
 import retrofit2.http.Query
 
-interface RemoteAgeServiceable {
+internal interface RemoteAgeServiceable {
 
     @GET(GET_BY_NAME)
     suspend fun getByName(

--- a/remote/age/src/main/java/com/buggily/ify/remote/age/RemoteAgeSource.kt
+++ b/remote/age/src/main/java/com/buggily/ify/remote/age/RemoteAgeSource.kt
@@ -1,6 +1,6 @@
 package com.buggily.ify.remote.age
 
-class RemoteAgeSource(
+internal class RemoteAgeSource(
     private val remoteAgeService: RemoteAgeServiceable,
 ) : RemoteAgeSourceable {
 

--- a/remote/age/src/main/java/com/buggily/ify/remote/age/di/AgeBaseUrlProvider.kt
+++ b/remote/age/src/main/java/com/buggily/ify/remote/age/di/AgeBaseUrlProvider.kt
@@ -8,7 +8,7 @@ import okhttp3.HttpUrl
 
 @Module
 @InstallIn(SingletonComponent::class)
-object AgeBaseUrlProvider {
+internal object AgeBaseUrlProvider {
 
     @Provides
     @AgeBaseUrlQualifier

--- a/remote/age/src/main/java/com/buggily/ify/remote/age/di/AgeRetrofitProvider.kt
+++ b/remote/age/src/main/java/com/buggily/ify/remote/age/di/AgeRetrofitProvider.kt
@@ -9,7 +9,7 @@ import retrofit2.Retrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
-object AgeRetrofitProvider {
+internal object AgeRetrofitProvider {
 
     @Provides
     @AgeRetrofitQualifier

--- a/remote/age/src/main/java/com/buggily/ify/remote/age/di/AgeServiceableProvider.kt
+++ b/remote/age/src/main/java/com/buggily/ify/remote/age/di/AgeServiceableProvider.kt
@@ -9,7 +9,7 @@ import retrofit2.Retrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
-object AgeServiceableProvider {
+internal object AgeServiceableProvider {
 
     @Provides
     fun provides(

--- a/remote/age/src/main/java/com/buggily/ify/remote/age/di/RemoteAgeSourceProvider.kt
+++ b/remote/age/src/main/java/com/buggily/ify/remote/age/di/RemoteAgeSourceProvider.kt
@@ -9,7 +9,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object RemoteAgeSourceProvider {
+internal object RemoteAgeSourceProvider {
 
     @Provides
     fun provides(

--- a/remote/age/src/main/java/com/buggily/ify/remote/age/di/RemoteAgeSourceableBinder.kt
+++ b/remote/age/src/main/java/com/buggily/ify/remote/age/di/RemoteAgeSourceableBinder.kt
@@ -9,7 +9,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-interface RemoteAgeSourceableBinder {
+internal interface RemoteAgeSourceableBinder {
 
     @Binds
     fun binds(

--- a/remote/gender/src/main/java/com/buggily/ify/remote/gender/RemoteGenderServiceable.kt
+++ b/remote/gender/src/main/java/com/buggily/ify/remote/gender/RemoteGenderServiceable.kt
@@ -4,7 +4,7 @@ import com.buggily.core.remote.ApiResult
 import retrofit2.http.GET
 import retrofit2.http.Query
 
-interface RemoteGenderServiceable {
+internal interface RemoteGenderServiceable {
 
     @GET(GET_BY_NAME)
     suspend fun getByName(

--- a/remote/gender/src/main/java/com/buggily/ify/remote/gender/RemoteGenderSource.kt
+++ b/remote/gender/src/main/java/com/buggily/ify/remote/gender/RemoteGenderSource.kt
@@ -1,6 +1,6 @@
 package com.buggily.ify.remote.gender
 
-class RemoteGenderSource(
+internal class RemoteGenderSource(
     private val remoteGenderService: RemoteGenderServiceable,
 ) : RemoteGenderSourceable {
 

--- a/remote/gender/src/main/java/com/buggily/ify/remote/gender/di/GenderBaseUrlProvider.kt
+++ b/remote/gender/src/main/java/com/buggily/ify/remote/gender/di/GenderBaseUrlProvider.kt
@@ -8,7 +8,7 @@ import okhttp3.HttpUrl
 
 @Module
 @InstallIn(SingletonComponent::class)
-object GenderBaseUrlProvider {
+internal object GenderBaseUrlProvider {
 
     @Provides
     @GenderBaseUrlQualifier

--- a/remote/gender/src/main/java/com/buggily/ify/remote/gender/di/GenderRetrofitProvider.kt
+++ b/remote/gender/src/main/java/com/buggily/ify/remote/gender/di/GenderRetrofitProvider.kt
@@ -9,7 +9,7 @@ import retrofit2.Retrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
-object GenderRetrofitProvider {
+internal object GenderRetrofitProvider {
 
     @Provides
     @GenderRetrofitQualifier

--- a/remote/gender/src/main/java/com/buggily/ify/remote/gender/di/GenderServiceableProvider.kt
+++ b/remote/gender/src/main/java/com/buggily/ify/remote/gender/di/GenderServiceableProvider.kt
@@ -9,7 +9,7 @@ import retrofit2.Retrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
-object GenderServiceableProvider {
+internal object GenderServiceableProvider {
 
     @Provides
     fun provides(

--- a/remote/gender/src/main/java/com/buggily/ify/remote/gender/di/RemoteGenderSourceProvider.kt
+++ b/remote/gender/src/main/java/com/buggily/ify/remote/gender/di/RemoteGenderSourceProvider.kt
@@ -9,7 +9,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object RemoteGenderSourceProvider {
+internal object RemoteGenderSourceProvider {
 
     @Provides
     fun provides(

--- a/remote/gender/src/main/java/com/buggily/ify/remote/gender/di/RemoteGenderSourceableBinder.kt
+++ b/remote/gender/src/main/java/com/buggily/ify/remote/gender/di/RemoteGenderSourceableBinder.kt
@@ -9,7 +9,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-interface RemoteGenderSourceableBinder {
+internal interface RemoteGenderSourceableBinder {
 
     @Binds
     fun binds(

--- a/remote/nationality/src/main/java/com/buggily/ify/remote/nationality/RemoteNationalityServiceable.kt
+++ b/remote/nationality/src/main/java/com/buggily/ify/remote/nationality/RemoteNationalityServiceable.kt
@@ -4,7 +4,7 @@ import com.buggily.core.remote.ApiResult
 import retrofit2.http.GET
 import retrofit2.http.Query
 
-interface RemoteNationalityServiceable {
+internal interface RemoteNationalityServiceable {
 
     @GET(GET_BY_NAME)
     suspend fun getByName(

--- a/remote/nationality/src/main/java/com/buggily/ify/remote/nationality/RemoteNationalitySource.kt
+++ b/remote/nationality/src/main/java/com/buggily/ify/remote/nationality/RemoteNationalitySource.kt
@@ -1,6 +1,6 @@
 package com.buggily.ify.remote.nationality
 
-class RemoteNationalitySource(
+internal class RemoteNationalitySource(
     private val remoteNationalityService: RemoteNationalityServiceable,
 ) : RemoteNationalitySourceable {
 

--- a/remote/nationality/src/main/java/com/buggily/ify/remote/nationality/di/NationalityBaseUrlProvider.kt
+++ b/remote/nationality/src/main/java/com/buggily/ify/remote/nationality/di/NationalityBaseUrlProvider.kt
@@ -8,7 +8,7 @@ import okhttp3.HttpUrl
 
 @Module
 @InstallIn(SingletonComponent::class)
-object NationalityBaseUrlProvider {
+internal object NationalityBaseUrlProvider {
 
     @Provides
     @NationalityBaseUrlQualifier

--- a/remote/nationality/src/main/java/com/buggily/ify/remote/nationality/di/NationalityRetrofitProvider.kt
+++ b/remote/nationality/src/main/java/com/buggily/ify/remote/nationality/di/NationalityRetrofitProvider.kt
@@ -9,7 +9,7 @@ import retrofit2.Retrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
-object NationalityRetrofitProvider {
+internal object NationalityRetrofitProvider {
 
     @Provides
     @NationalityRetrofitQualifier

--- a/remote/nationality/src/main/java/com/buggily/ify/remote/nationality/di/NationalityServiceableProvider.kt
+++ b/remote/nationality/src/main/java/com/buggily/ify/remote/nationality/di/NationalityServiceableProvider.kt
@@ -9,7 +9,7 @@ import retrofit2.Retrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
-object NationalityServiceableProvider {
+internal object NationalityServiceableProvider {
 
     @Provides
     fun provides(

--- a/remote/nationality/src/main/java/com/buggily/ify/remote/nationality/di/NationalitySourceProvider.kt
+++ b/remote/nationality/src/main/java/com/buggily/ify/remote/nationality/di/NationalitySourceProvider.kt
@@ -9,7 +9,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object NationalitySourceProvider {
+internal object NationalitySourceProvider {
 
     @Provides
     fun provides(

--- a/remote/nationality/src/main/java/com/buggily/ify/remote/nationality/di/NationalitySourceableBinder.kt
+++ b/remote/nationality/src/main/java/com/buggily/ify/remote/nationality/di/NationalitySourceableBinder.kt
@@ -9,7 +9,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-interface NationalitySourceableBinder {
+internal interface NationalitySourceableBinder {
 
     @Binds
     fun binds(


### PR DESCRIPTION
- declare providers and binders as `internal`
- capitalize input name when displayed
- rename error string literal